### PR TITLE
Render brew class with template. Add Linux support

### DIFF
--- a/clojure-lsp-native.rb.tmpl
+++ b/clojure-lsp-native.rb.tmpl
@@ -1,0 +1,18 @@
+class ClojureLspNative < Formula
+  desc "Language Server (LSP) for Clojure"
+  homepage "https://github.com/clojure-lsp/clojure-lsp"
+  version "<version>"
+  bottle :unneeded
+
+  if OS.mac?
+    url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-macos-amd64.zip"
+    sha256 "<mac-sha>"
+  elsif OS.linux?
+    url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-linux-amd64.zip"
+    sha256 "<linux-sha>"
+  end
+
+  def install
+    bin.install "clojure-lsp"
+  end
+end

--- a/render.clj
+++ b/render.clj
@@ -1,0 +1,30 @@
+#!/usr/bin/env bb
+
+(require '[clojure.tools.cli :refer [parse-opts]]
+         '[clojure.string :as str])
+
+(def cli-options
+  [[nil "--mac-sha SHA" "The sha256 of the mac artifact"
+    :default ""
+    :missing "--mac-sha must be specified"]
+   [nil "--linux-sha SHA" "The sha256 of the linux artifact"
+    :default ""
+    :missing "--linux-sha must be specified"]
+   [nil "--version VERSION" "The new version to publish"
+    :default ""
+    :missing "--linux-sha must be specified"]
+   [nil "--template" "Path of the template file"
+    :default "clojure-lsp-native.rb.tmpl"]])
+
+
+(defn render
+  [{:keys [version linux-sha mac-sha template]}]
+  (-> (slurp template)
+      (str/replace #"<version>" version)
+      (str/replace #"<linux-sha>" linux-sha)
+      (str/replace #"<mac-sha>" mac-sha)))
+
+(-> (parse-opts *command-line-args* cli-options)
+    :options
+    render)
+


### PR DESCRIPTION
Adds a small go program that renders the included template into the brew Rubyclass.

This is more robust than the current sed implementation.

The template also adds support for Linuxbrew. It's not possible to use the current sed implementation to template 2 different SHAs.

I will link the PR with the corresponding github actions changes.