### PR TITLE
Add shasum of the linux binary

### DIFF
--- a/clojure-lsp-native.rb
+++ b/clojure-lsp-native.rb
@@ -9,7 +9,7 @@ class ClojureLspNative < Formula
     sha256 "1740e764bdfb1380d5d465ca4af3770de082a1a341acc381fcf29afd3313a143"
   elsif OS.linux?
     url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.04.27-20.17.45/clojure-lsp-native-linux-amd64.zip"
-    sha256 ""
+    sha256 "afa4493f251135f56dd74eb64348a89a413e40528769607cf044b94aa4644295"
   end
 
   def install


### PR DESCRIPTION
Due to a typo in the Github Action which computes the shasum, it was empty.
This change patches the Homebrew spec for this release, another PR is done to ensure the shasum is present for future releases.