### PR TITLE
Remove bottle :unneeded from brew formula

### DIFF
--- a/clojure-lsp-native.rb
+++ b/clojure-lsp-native.rb
@@ -2,7 +2,6 @@ class ClojureLspNative < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   version "2021.10.20-13.04.11"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.10.20-13.04.11/clojure-lsp-native-macos-amd64.zip"

--- a/clojure-lsp-native.rb.tmpl
+++ b/clojure-lsp-native.rb.tmpl
@@ -2,7 +2,6 @@ class ClojureLspNative < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   version "<version>"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-macos-amd64.zip"


### PR DESCRIPTION
Homebrew deprecated bottle :unneeded in Homebrew/brew@f65d525, which now issues this warning:

    Warning: Calling bottle :unneeded is deprecated! There is no replacement.