### PR TITLE
Add with-static option to install static clojure-lsp binary

### DIFF
--- a/clojure-lsp-native.rb.tmpl
+++ b/clojure-lsp-native.rb.tmpl
@@ -3,6 +3,8 @@ class ClojureLspNative < Formula
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   version "<version>"
 
+  option "with-static", "Installs statically built binary."
+
   if OS.mac?
     if Hardware::CPU.arm?
       url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-macos-aarch64.zip"
@@ -12,8 +14,13 @@ class ClojureLspNative < Formula
       sha256 "<mac-amd-sha>"
     end
   elsif OS.linux?
-    url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-linux-amd64.zip"
-    sha256 "<linux-sha>"
+    if build.with? "static"
+      url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-static-linux-amd64.zip"
+      sha256 "<static-linux-sha>"
+    else
+      url "https://github.com/clojure-lsp/clojure-lsp/releases/download/<version>/clojure-lsp-native-linux-amd64.zip"
+      sha256 "<linux-sha>"
+    end
   end
 
   def install

--- a/render.clj
+++ b/render.clj
@@ -13,6 +13,9 @@
    [nil "--linux-sha SHA" "The sha256 of the linux artifact"
     :default ""
     :missing "--linux-sha must be specified"]
+   [nil "--static-linux-sha SHA" "The sha256 of the static linux artifact"
+    :default ""
+    :missing "--static-linux-sha must be specified"]
    [nil "--version VERSION" "The new version to publish"
     :default ""
     :missing "--linux-sha must be specified"]
@@ -21,10 +24,11 @@
 
 
 (defn render
-  [{:keys [version linux-sha mac-amd-sha mac-arm-sha template]}]
+  [{:keys [version linux-sha static-linux-sha mac-amd-sha mac-arm-sha template]}]
   (-> (slurp template)
       (str/replace #"<version>" version)
       (str/replace #"<linux-sha>" linux-sha)
+      (str/replace #"<static-linux-sha>" static-linux-sha)
       (str/replace #"<mac-arm-sha>" mac-arm-sha)
       (str/replace #"<mac-amd-sha>" mac-amd-sha)))
 


### PR DESCRIPTION
Allow choosing the static binary when installing via brew.

I ran into [this](https://github.com/clojure-lsp/clojure-lsp/issues/1415) and saw that the workaround was to use static, so adding that same pattern here.

- [ ] Would you be able to help me generate the actual formula? I ran the `render.clj` script but wasn't able to pipe it out properly formatted